### PR TITLE
add to javaOptions instead of replacing them

### DIFF
--- a/AppPlugin.scala
+++ b/AppPlugin.scala
@@ -30,8 +30,8 @@ object AppPlugin extends AutoPlugin {
     }
 
     Seq(
-      javaOptions in run := customOpts(baseDirectory.value / "dev" / "main"),
-      javaOptions in Test := customOpts(baseDirectory.value / "dev" / "test")
+      javaOptions in run ++= customOpts(baseDirectory.value / "dev" / "main"),
+      javaOptions in Test ++= customOpts(baseDirectory.value / "dev" / "test")
     )
   }
 

--- a/AppPlugin.scala
+++ b/AppPlugin.scala
@@ -11,8 +11,8 @@ object AppPlugin extends AutoPlugin {
     Seq(
       crossPaths := false,
       crossScalaVersions := Seq(scalaVersion.value),
-      publishArtifact in (Compile, packageDoc) := false,
-      publishArtifact in (Compile, packageSrc) := false
+      Compile / packageDoc / publishArtifact := false,
+      Compile / packageSrc / publishArtifact := false
     ) ++
     Seq(
       version := sys.props.getOrElse("application.version",
@@ -30,8 +30,8 @@ object AppPlugin extends AutoPlugin {
     }
 
     Seq(
-      javaOptions in run ++= customOpts(baseDirectory.value / "dev" / "main"),
-      javaOptions in Test ++= customOpts(baseDirectory.value / "dev" / "test")
+      run  / javaOptions ++= customOpts(baseDirectory.value / "dev" / "main"),
+      Test / javaOptions ++= customOpts(baseDirectory.value / "dev" / "test")
     )
   }
 

--- a/BasicPlugin.scala
+++ b/BasicPlugin.scala
@@ -19,7 +19,7 @@ object BasicPlugin extends AutoPlugin {
       "-source", javaVersion,
       "-target", javaVersion
     ),
-    javacOptions in doc ++= Seq(
+    doc / javacOptions ++= Seq(
       "-source", javaVersion
     ),
     scalacOptions ++= Seq(
@@ -30,13 +30,13 @@ object BasicPlugin extends AutoPlugin {
       "-Xlog-reflective-calls",
       "-Xlint",
       "-Ywarn-value-discard"
-    ) ++ ((scalaBinaryVersion in pluginCrossBuild).value match {
+    ) ++ ((pluginCrossBuild / scalaBinaryVersion).value match {
       case v if v == "2.11" || v == "2.12" => Seq("-Ywarn-unused-import", s"-target:jvm-$javaVersion")
       case v if v == "2.13" => Seq("-Ywarn-unused:imports", s"-target:jvm-$javaVersion")
       case _ => Seq.empty
     }),
-    scalacOptions in console -= "-Ywarn-unused-import",
-    parallelExecution in Compile := true
+    console / scalacOptions -= "-Ywarn-unused-import",
+    Compile / parallelExecution := true
   )
 
   val checkJavaVersionCompliance = (s: State) => {
@@ -48,12 +48,12 @@ object BasicPlugin extends AutoPlugin {
   }
 
   val miscSettings = Seq(
-    cancelable in Global := true,
-    parallelExecution in Test := true,
-    fork in Test := true,
-    fork in run := true,
-    onLoad in Global :=
-      checkJavaVersionCompliance compose (onLoad in Global).value
+    Global / cancelable := true,
+    Test / parallelExecution := true,
+    Test / fork := true,
+    run / fork := true,
+    Global / onLoad :=
+      checkJavaVersionCompliance compose (Global / onLoad).value
   )
 
   val publishSettings =

--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,8 @@ releaseCrossBuild := false
 scalaVersion := tnm.ScalaVersion.prev
 
 libraryDependencies ++= {
-  val sbtV = (sbtBinaryVersion in pluginCrossBuild).value
-  val scalaV = (scalaBinaryVersion in pluginCrossBuild).value
+  val sbtV = (pluginCrossBuild / sbtBinaryVersion).value
+  val scalaV = (pluginCrossBuild / scalaBinaryVersion).value
 
   Seq(
     "com.github.gseitz" % "sbt-release" % "1.0.13",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,4 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 addSbtPlugin("no.arktekk.sbt" % "aether-deploy" % "0.25.0")
 
 // Use itself as a plugin
-unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile
+Compile / unmanagedSourceDirectories += baseDirectory.value.getParentFile

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.1.2-SNAPSHOT"
+ThisBuild / version := "5.1.2-SNAPSHOT"


### PR DESCRIPTION
add to javaOptions instead of replacing them. that way you can pass custom options from your build.sbt.

The PR also take us from the old 'in' syntax to the slash syntax introduced in SBT 1.1